### PR TITLE
Adjust formatting to new logcat style

### DIFF
--- a/coloredlogcat.py
+++ b/coloredlogcat.py
@@ -36,12 +36,13 @@ IGNORED = [
 
 # Width of various columns; set to -1 to hide
 TIME_WIDTH = 18 
+PPID_WIDTH = 7
 USER_WIDTH = 3
-PROCESS_WIDTH = 8
+PROCESS_WIDTH = 7
 TAG_WIDTH = 20
 PRIORITY_WIDTH = 3
 
-HEADER_SIZE = TIME_WIDTH + USER_WIDTH + PROCESS_WIDTH + TAG_WIDTH + PRIORITY_WIDTH + 4
+HEADER_SIZE = TIME_WIDTH + PPID_WIDTH + USER_WIDTH + PROCESS_WIDTH + TAG_WIDTH + PRIORITY_WIDTH + 6
 
 # unpack the current terminal width/height
 data = fcntl.ioctl(sys.stdout.fileno(), termios.TIOCGWINSZ, '1234')
@@ -168,7 +169,7 @@ while True:
 
     # time
     if TIME_WIDTH > 0:
-        linebuf.write(time)
+        linebuf.write("%s%s%s " % (format(fg=GREEN, bg=BLACK, bright=False), time, format(reset=True)))
 
     # center user info
     if USER_WIDTH > 0:
@@ -180,6 +181,11 @@ while True:
             linebuf.write("%s%s%s " % (format(fg=BLACK, bg=color, bright=False), user, format(reset=True)))
         else:
             linebuf.write(" " * (USER_WIDTH + 1))
+
+    # ppid
+    if PPID_WIDTH > 0:
+        ppid = ppid.strip().center(PPID_WIDTH)
+        linebuf.write("%s%s%s " % (format(fg=BLACK, bg=BLACK, bright=True), ppid, format(reset=True)))
 
     # center process info
     if PROCESS_WIDTH > 0:

--- a/coloredlogcat.py
+++ b/coloredlogcat.py
@@ -37,7 +37,7 @@ IGNORED = [
 # Width of various columns; set to -1 to hide
 TIME_WIDTH = 18 
 PPID_WIDTH = 7
-USER_WIDTH = 3
+USER_WIDTH = 0
 PROCESS_WIDTH = 7
 TAG_WIDTH = 20
 PRIORITY_WIDTH = 3
@@ -78,7 +78,7 @@ def indent_wrap(message, indent=0, width=80):
     return messagebuf.getvalue()
 
 USER_COLORS = [BLUE,YELLOW,RED,GREEN,MAGENTA,CYAN]
-LAST_USED = [RED,GREEN,YELLOW,BLUE,MAGENTA,CYAN,WHITE]
+LAST_USED = [RED,GREEN,YELLOW,MAGENTA,CYAN,WHITE]
 KNOWN_TAGS = {
     "dalvikvm": BLUE,
     "art": BLUE,
@@ -105,7 +105,7 @@ def allocate_color(tag):
     return color
 
 PRIORITIES = {
-    "V": "%s%s%s " % (format(fg=WHITE, bg=BLACK), "V".center(PRIORITY_WIDTH), format(reset=True)),
+    "V": "%s%s%s " % (format(fg=BLACK, bg=WHITE), "V".center(PRIORITY_WIDTH), format(reset=True)),
     "D": "%s%s%s " % (format(fg=BLACK, bg=BLUE), "D".center(PRIORITY_WIDTH), format(reset=True)),
     "I": "%s%s%s " % (format(fg=BLACK, bg=GREEN), "I".center(PRIORITY_WIDTH), format(reset=True)),
     "W": "%s%s%s " % (format(fg=BLACK, bg=YELLOW), "W".center(PRIORITY_WIDTH), format(reset=True)),
@@ -198,6 +198,13 @@ while True:
         process = process.strip().center(PROCESS_WIDTH)
         linebuf.write("%s%s%s " % (format(fg=BLACK, bg=BLACK, bright=True), process, format(reset=True)))
 
+    # write out tagtype colored edge
+    if not priority in PRIORITIES:
+        print line
+        continue
+
+    linebuf.write(PRIORITIES[priority])
+
     # right-align tag title and allocate color if needed
     tag = tag.strip()
     if "avc: denied" in message:
@@ -210,13 +217,6 @@ while True:
         color = allocate_color(tag)
         tag = tag[-line_tag_width:].rjust(line_tag_width)
         linebuf.write("%s%s%s " % (format(fg=color, dim=False), tag, format(reset=True)))
-
-    # write out tagtype colored edge
-    if not priority in PRIORITIES:
-        print line
-        continue
-
-    linebuf.write(PRIORITIES[priority])
 
     # color any high-millis operations
     message = retime.sub(millis_color, message)


### PR DESCRIPTION
Thanks @bigtree9307 for updating this script, there's still a few lines that don't work though, for example this:
```
01-15 14:44:13.202  3672  8072 D SSRM:d  : SIOP:: AP = 260, PST = 261 (W:6), BAT = 238, CHG = 251, CP = 214
```
![Screenshot_20200115_144622](https://user-images.githubusercontent.com/13354331/72439057-7aa5b380-37a6-11ea-995b-c3e7166b553c.png)

