### PR TITLE
Ignore encoding errors

### DIFF
--- a/coloredlogcat.py
+++ b/coloredlogcat.py
@@ -142,6 +142,8 @@ else:
 while True:
     try:
         line = input.readline()
+    except UnicodeDecodeError:
+        pass
     except KeyboardInterrupt:
         break
 


### PR DESCRIPTION
In case the Android project in question has non-English logcat outputs, some encoding errors caused the loop to stop as per image below:

![image](https://user-images.githubusercontent.com/5889585/140057661-b4f498db-5867-492d-8931-190b3c5ef8ac.png)

This happens because the only exception handled is meant to interrupt the loop intentionally. 

So adding a special case for UnicodeDecodeError to keep the running alive could be a work-around.